### PR TITLE
Fixes release upload tag so it uploads to an existing release.

### DIFF
--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -176,4 +176,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           file: "smart-contract/artifacts/*.wasm;smart-contract/artifacts/checksums-dcc.txt;smart-contract-sale/artifacts/*wasm;smart-contract-sale/artifacts/checksums-dcc_sale.txt"
+          tag_name: ${{ github.ref_name }}
+          draft:
+          prerelease:
         if: github.event_name == 'release'


### PR DESCRIPTION
The documentation [here](https://github.com/xresloader/upload-to-github-release) wasn't incredibly clear but I looked at the code directly and it appears we can use `tag_name` to control the artifact uploads.

Here's what it was doing previously.

```
Run xresloader/upload-to-github-release@v1
File found to upload: /home/runner/work/digital-currency-consortium/digital-currency-consortium/smart-contract/artifacts/dcc.wasm
File found to upload: /home/runner/work/digital-currency-consortium/digital-currency-consortium/smart-contract/artifacts/checksums-dcc.txt
File found to upload: /home/runner/work/digital-currency-consortium/digital-currency-consortium/smart-contract-sale/artifacts/dcc_sale.wasm
File found to upload: /home/runner/work/digital-currency-consortium/digital-currency-consortium/smart-contract-sale/artifacts/checksums-dcc_sale.txt
Try to get release by tag v0.18.3-de60195f from FigureTechnologies/digital-currency-consortium
Try to get release by tag v0.18.3-de60195f from FigureTechnologies/digital-currency-consortium : Not Found
Try to get draft release name v0.18.3-de60195f or tag name v0.18.3-de60195f from FigureTechnologies/digital-currency-consortium
Try to create release v0.18.3-de60195f for FigureTechnologies/digital-currency-consortium
Create release v0.18.3-de60195f for FigureTechnologies/digital-currency-consortium success
Start uploading asset: /home/runner/work/digital-currency-consortium/digital-currency-consortium/smart-contract/artifacts/dcc.wasm(size: 342657) ...
Upload asset: dcc.wasm success
Start uploading asset: /home/runner/work/digital-currency-consortium/digital-currency-consortium/smart-contract/artifacts/checksums-dcc.txt(size: 75) ...
Upload asset: checksums-dcc.txt success
Start uploading asset: /home/runner/work/digital-currency-consortium/digital-currency-consortium/smart-contract-sale/artifacts/dcc_sale.wasm(size: 234172) ...
Upload asset: dcc_sale.wasm success
Start uploading asset: /home/runner/work/digital-currency-consortium/digital-currency-consortium/smart-contract-sale/artifacts/checksums-dcc_sale.txt(size: 80) ...
Upload asset: checksums-dcc_sale.txt success
```

![Screen Shot 2023-03-28 at 9 16 39 AM](https://user-images.githubusercontent.com/541726/228256226-8e296b95-4ded-482a-a95a-deba0b504ac4.png)
