### PR TITLE
chore: update codeowners for new team structure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,1 @@
-# CODEOWNERS: https://help.github.com/articles/about-codeowners/
-
-# NOTE: Order is important; the last matching pattern takes the
-# most precedence.
-
-# Primary repo maintainers
-*       @ranadewall @scirner22 @jtalis @leeduan @mwoods-figure
+* @FigureTechnologies/backend-platform-cme


### PR DESCRIPTION
**Problem:** 

We're updating team organization and codeowners to better match company & team structure

**Solution:**

Update this repo per assignments per [notion docs](https://www.notion.so/figuretech/1be68c6593194b989619f3f9af07b87d?v=ff5860acd9e8441bb374f42f68df7f08)